### PR TITLE
Fix JSTL dependency in esup-commons2-jsf-trinidad

### DIFF
--- a/esup-commons-jsf-parent/esup-commons-jsf-trinidad/pom.xml
+++ b/esup-commons-jsf-parent/esup-commons-jsf-trinidad/pom.xml
@@ -31,7 +31,7 @@
             <version>1.2.9</version>
         </dependency>
         <dependency>
-            <groupId>jstl</groupId>
+            <groupId>javax.servlet</groupId>
             <artifactId>jstl</artifactId>
             <version>1.1.2</version>
         </dependency>


### PR DESCRIPTION
`jstl:jstl:1.1.2` has moved to `javax.servlet:jstl:1.1.2`
