### PR TITLE
Update esup-commons-core/src/main/java/org/esupportail/commons/services/...

### DIFF
--- a/esup-commons-core/src/main/java/org/esupportail/commons/services/smtp/SmtpServer.java
+++ b/esup-commons-core/src/main/java/org/esupportail/commons/services/smtp/SmtpServer.java
@@ -80,7 +80,6 @@ public class SmtpServer implements InitializingBean, Serializable {
 			this.user = null;
 			logger.info(getClass() + ": an anonymous connection will be used for SMTP server '"
 					+ this.host + ":" + this.port + "'.");
-			setDefaultPort();
 			if (StringUtils.hasText(this.password)) {
 				logger.warn(getClass() + ": an anonymous connection will be used for SMTP server '"
 						+ this.host + ":" + this.port + "', password ignored.");


### PR DESCRIPTION
...smtp/SmtpServer.java

Why force the smtp port to 25 when no smtp user is configured ? 
